### PR TITLE
Add user_id, player_gid, and machine_id to GameClient

### DIFF
--- a/wizwalker/memory/memory_objects/game_client.py
+++ b/wizwalker/memory/memory_objects/game_client.py
@@ -175,6 +175,18 @@ class GameClient(MemoryObject):
         )
         await self.write_value_to_offset(offset, shutdown_signal, Primitive.int32)
 
+    async def user_id(self) -> int:
+        """Account-level UserID from MSG_USER_VALIDATE / MSG_CHARACTERSELECTED."""
+        return await self.read_value_from_offset(0x21258, Primitive.uint64)
+
+    async def player_gid(self) -> int:
+        """Current character's global ID (CharID from MSG_CHARACTERSELECTED)."""
+        return await self.read_value_from_offset(0x214C0, Primitive.uint64)
+
+    async def machine_id(self) -> int:
+        """MachineID sent during login."""
+        return await self.read_value_from_offset(0x214C8, Primitive.uint64)
+
     async def character_registry(self) -> Optional[DynamicCharacterRegistry]:
         """
         Get the character registry


### PR DESCRIPTION
## Summary
- Add `user_id()` (offset 0x21258) account-level UserID from login
- Add `player_gid()` (offset 0x214C0) character GID (CharID from MSG_CHARACTERSELECTED)
- Add `machine_id()` (offset 0x214C8) MachineID sent during login

## Verification
Offsets verified via Ghidra static analysis of the `MSG_UserValidateRsp` handler in r794561, and confirmed live with Cheat Engine against WizardGraphicalClient.exe.

## Usage
```python
user_id    = await client.game_client.user_id()
player_gid = await client.game_client.player_gid()
machine_id = await client.game_client.machine_id()
```