### PR TITLE
Chat send/receive hooks + buddy request support

### DIFF
--- a/examples/chat_test.py
+++ b/examples/chat_test.py
@@ -35,10 +35,15 @@ async def main():
         print("Activating chat send hook...")
         await client.hook_handler.activate_chat_send_hook()
 
+        print("Activating chat receive hook...")
+        await client.hook_handler.activate_chat_hook(wait_for_ready=False)
+
         print("\n=== Chat & Buddy Test CLI ===")
         print("  1      - Get your GID")
         print("  2      - Send directed chat to a GID")
         print("  3      - Send buddy request to a GID")
+        print("  4      - Wait for incoming whisper")
+        print("  5      - Read last received whisper")
         print("  Ctrl+C - Exit\n")
 
         while True:
@@ -91,13 +96,34 @@ async def main():
                 except Exception as e:
                     print(f"  Failed: {e}")
 
+            elif choice == "4":
+                print("  Waiting for incoming whisper (10s timeout)...")
+                try:
+                    sender, msg, cnt = await client.chat_owner.wait_for_message(10.0)
+                    print(f"  From {sender}: {msg!r} (msg #{cnt})")
+                except asyncio.TimeoutError:
+                    print("  No message received within timeout")
+                except Exception as e:
+                    print(f"  Error: {e}")
+
+            elif choice == "5":
+                try:
+                    sender, msg, cnt = await client.chat_owner.recv_message()
+                    print(f"  From {sender}: {msg!r} (msg #{cnt})")
+                except Exception as e:
+                    print(f"  Error: {e}")
+
             else:
-                print("  Unknown option. Use 1, 2, 3, or Ctrl+C.")
+                print("  Unknown option. Use 1-5 or Ctrl+C.")
 
     except KeyboardInterrupt:
         print("\nCtrl+C received")
     finally:
         print("Unhooking...")
+        try:
+            await client.hook_handler.deactivate_chat_hook()
+        except Exception:
+            pass
         try:
             await client.hook_handler.deactivate_chat_send_hook()
         except Exception:

--- a/examples/chat_test.py
+++ b/examples/chat_test.py
@@ -1,14 +1,15 @@
-"""Chat test CLI.
+"""Chat and buddy test CLI.
 
 Run on 2 game clients. Use option 1 to get each client's GID,
-then use option 2 on one client to send a whisper to the other.
+then use option 2 to send a whisper or option 3 to send a buddy request.
 
-Sending uses the GameClient (already hooked via ClientHook) —
-no ChatHook needed. ChatHook is only for reading incoming messages.
+Requires ChatSendHook which hooks the game's main loop to execute
+social actions on the main thread safely.
 
 Controls:
   1      - Print your character's GID
   2      - Send a directed chat message to a target GID
+  3      - Send buddy request to a GID
   Ctrl+C - Unhook cleanly and exit
 """
 
@@ -31,12 +32,13 @@ async def main():
         print("Activating hooks...")
         await client.activate_hooks()
 
-        print("Activating chat send hook (main-thread send)...")
+        print("Activating chat send hook...")
         await client.hook_handler.activate_chat_send_hook()
 
-        print("\n=== Chat Test CLI ===")
+        print("\n=== Chat & Buddy Test CLI ===")
         print("  1      - Get your GID")
         print("  2      - Send directed chat to a GID")
+        print("  3      - Send buddy request to a GID")
         print("  Ctrl+C - Exit\n")
 
         while True:
@@ -72,8 +74,25 @@ async def main():
                 except Exception as e:
                     print(f"  Send failed: {e}")
 
+            elif choice == "3":
+                target_str = await asyncio.get_event_loop().run_in_executor(
+                    None, lambda: input("  Target GID: ").strip()
+                )
+                try:
+                    target_gid = int(target_str)
+                except ValueError:
+                    print("  Invalid GID")
+                    continue
+
+                print(f"  Sending buddy request to {target_gid}...")
+                try:
+                    await client.chat_owner.add_player(target_gid)
+                    print("  Sent!")
+                except Exception as e:
+                    print(f"  Failed: {e}")
+
             else:
-                print("  Unknown option. Use 1, 2, or Ctrl+C.")
+                print("  Unknown option. Use 1, 2, 3, or Ctrl+C.")
 
     except KeyboardInterrupt:
         print("\nCtrl+C received")

--- a/examples/chat_test.py
+++ b/examples/chat_test.py
@@ -1,0 +1,91 @@
+"""Chat test CLI.
+
+Run on 2 game clients. Use option 1 to get each client's GID,
+then use option 2 on one client to send a whisper to the other.
+
+Sending uses the GameClient (already hooked via ClientHook) —
+no ChatHook needed. ChatHook is only for reading incoming messages.
+
+Controls:
+  1      - Print your character's GID
+  2      - Send a directed chat message to a target GID
+  Ctrl+C - Unhook cleanly and exit
+"""
+
+import asyncio
+
+from wizwalker import ClientHandler
+
+
+async def main():
+    handler = ClientHandler()
+    clients = handler.get_new_clients()
+    if not clients:
+        print("No game clients found. Launch Wizard101 first.")
+        return
+
+    client = clients[0]
+    print(f"Attached to client (PID: {client._pymem.process_id})")
+
+    try:
+        print("Activating hooks...")
+        await client.activate_hooks()
+
+        print("Activating chat send hook (main-thread send)...")
+        await client.hook_handler.activate_chat_send_hook()
+
+        print("\n=== Chat Test CLI ===")
+        print("  1      - Get your GID")
+        print("  2      - Send directed chat to a GID")
+        print("  Ctrl+C - Exit\n")
+
+        while True:
+            choice = await asyncio.get_event_loop().run_in_executor(
+                None, lambda: input("> ").strip()
+            )
+
+            if choice == "1":
+                gid = await client.game_client.player_gid()
+                print(f"  Your GID: {gid}")
+
+            elif choice == "2":
+                target_str = await asyncio.get_event_loop().run_in_executor(
+                    None, lambda: input("  Target GID: ").strip()
+                )
+                try:
+                    target_gid = int(target_str)
+                except ValueError:
+                    print("  Invalid GID")
+                    continue
+
+                msg = await asyncio.get_event_loop().run_in_executor(
+                    None, lambda: input("  Message: ").strip()
+                )
+                if not msg:
+                    print("  Empty message")
+                    continue
+
+                print(f"  Sending to {target_gid}: {msg!r}")
+                try:
+                    await client.chat_owner.send_msg(msg, target_gid=target_gid)
+                    print("  Sent!")
+                except Exception as e:
+                    print(f"  Send failed: {e}")
+
+            else:
+                print("  Unknown option. Use 1, 2, or Ctrl+C.")
+
+    except KeyboardInterrupt:
+        print("\nCtrl+C received")
+    finally:
+        print("Unhooking...")
+        try:
+            await client.hook_handler.deactivate_chat_send_hook()
+        except Exception:
+            pass
+        await handler.close()
+        print("Done.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/wizwalker/client.py
+++ b/wizwalker/client.py
@@ -17,6 +17,7 @@ from .constants import WIZARD_SPEED, Primitive
 from .errors import PatternMultipleResults
 from .memory import (
     CurrentActorBody,
+    CurrentChatOwner,
     CurrentClientObject,
     CurrentDuel,
     CurrentGameStats,
@@ -75,6 +76,7 @@ class Client:
         self.render_context = CurrentRenderContext(self.hook_handler)
         self.game_client = CurrentGameClient(self.hook_handler)
         self.social_systems_manager = CurrentSocialSystemsManager(self.hook_handler)
+        self.chat_owner = CurrentChatOwner(self.hook_handler)
 
         self._teleport_helper = TeleportHelper(self.hook_handler)
 

--- a/wizwalker/memory/handler.py
+++ b/wizwalker/memory/handler.py
@@ -9,6 +9,8 @@ from loguru import logger
 
 from wizwalker import HookAlreadyActivated, HookNotActive, HookNotReady
 from .hooks import (
+    ChatHook,
+    ChatSendHook,
     ClientHook,
     MouselessCursorMoveHook,
     PlayerHook,
@@ -583,3 +585,86 @@ class HookHandler(MemoryReader):
         packed_position = struct.pack("<ii", x, y)
 
         await self.write_bytes(addr, packed_position)
+
+    async def activate_chat_hook(
+        self, *, wait_for_ready: bool = True, timeout: float = None
+    ):
+        """Activate the chat hook to capture the chat module pointer.
+
+        The hook fires on every incoming MSG_DirectedChat, capturing the
+        chat owner object and the current DML message pointer.
+
+        Keyword Args:
+            wait_for_ready: Wait for the chat owner pointer to be written
+            timeout: How long to wait (None for no timeout)
+        """
+        if self._check_if_hook_active(ChatHook):
+            raise HookAlreadyActivated("Chat")
+
+        await self._check_for_autobot()
+
+        chat_hook = ChatHook(self)
+        await chat_hook.hook()
+
+        self._active_hooks[ChatHook] = chat_hook
+        self._base_addrs["chat_owner"] = chat_hook.chat_owner_addr
+        self._base_addrs["chat_message"] = chat_hook.chat_message_addr
+
+        if wait_for_ready:
+            await self._wait_for_value(chat_hook.chat_owner_addr, timeout)
+
+    async def deactivate_chat_hook(self):
+        """Deactivate the chat hook."""
+        if not self._check_if_hook_active(ChatHook):
+            raise HookNotActive("Chat")
+
+        hook = self._active_hooks.pop(ChatHook)
+        await hook.unhook()
+
+        del self._base_addrs["chat_owner"]
+        del self._base_addrs["chat_message"]
+
+    async def read_chat_owner_base(self) -> int:
+        """Read the chat owner (chat module) base address.
+
+        Returns:
+            The chat module base address
+        """
+        return await self._read_hook_base_addr("chat_owner", "Chat")
+
+    async def read_chat_message_base(self) -> int:
+        """Read the current DML message pointer (transient, only valid during handler).
+
+        Returns:
+            The current DML message base address
+        """
+        return await self._read_hook_base_addr("chat_message", "Chat")
+
+    async def activate_chat_send_hook(self):
+        """Activate the chat send hook on the main game loop.
+
+        This hooks the game's main loop so that send_msg() executes
+        on the main thread where chat operations are safe.
+        """
+        if self._check_if_hook_active(ChatSendHook):
+            raise HookAlreadyActivated("Chat send")
+
+        await self._check_for_autobot()
+
+        hook = ChatSendHook(self)
+        await hook.hook()
+
+        self._active_hooks[ChatSendHook] = hook
+        self._base_addrs["send_trigger"] = hook.send_trigger
+        self._base_addrs["send_struct"] = hook.send_struct
+
+    async def deactivate_chat_send_hook(self):
+        """Deactivate the chat send hook."""
+        if not self._check_if_hook_active(ChatSendHook):
+            raise HookNotActive("Chat send")
+
+        hook = self._active_hooks.pop(ChatSendHook)
+        await hook.unhook()
+
+        del self._base_addrs["send_trigger"]
+        del self._base_addrs["send_struct"]

--- a/wizwalker/memory/handler.py
+++ b/wizwalker/memory/handler.py
@@ -657,6 +657,8 @@ class HookHandler(MemoryReader):
         self._active_hooks[ChatSendHook] = hook
         self._base_addrs["send_trigger"] = hook.send_trigger
         self._base_addrs["send_struct"] = hook.send_struct
+        self._base_addrs["buddy_trigger"] = hook.buddy_trigger
+        self._base_addrs["buddy_obj"] = hook.buddy_obj
 
     async def deactivate_chat_send_hook(self):
         """Deactivate the chat send hook."""
@@ -668,3 +670,5 @@ class HookHandler(MemoryReader):
 
         del self._base_addrs["send_trigger"]
         del self._base_addrs["send_struct"]
+        del self._base_addrs["buddy_trigger"]
+        del self._base_addrs["buddy_obj"]

--- a/wizwalker/memory/handler.py
+++ b/wizwalker/memory/handler.py
@@ -589,13 +589,13 @@ class HookHandler(MemoryReader):
     async def activate_chat_hook(
         self, *, wait_for_ready: bool = True, timeout: float = None
     ):
-        """Activate the chat hook to capture the chat module pointer.
+        """Activate the chat hook to capture incoming directed chat messages.
 
-        The hook fires on every incoming MSG_DirectedChat, capturing the
-        chat owner object and the current DML message pointer.
+        The hook fires on every incoming MSG_DirectedChat, extracting the
+        sender's GID and message text to persistent export buffers.
 
         Keyword Args:
-            wait_for_ready: Wait for the chat owner pointer to be written
+            wait_for_ready: Wait for the first message to arrive
             timeout: How long to wait (None for no timeout)
         """
         if self._check_if_hook_active(ChatHook):
@@ -608,10 +608,13 @@ class HookHandler(MemoryReader):
 
         self._active_hooks[ChatHook] = chat_hook
         self._base_addrs["chat_owner"] = chat_hook.chat_owner_addr
-        self._base_addrs["chat_message"] = chat_hook.chat_message_addr
+        self._base_addrs["recv_source_gid"] = chat_hook.recv_source_gid
+        self._base_addrs["recv_message_buf"] = chat_hook.recv_message_buf
+        self._base_addrs["recv_message_len"] = chat_hook.recv_message_len
+        self._base_addrs["recv_counter"] = chat_hook.recv_counter
 
         if wait_for_ready:
-            await self._wait_for_value(chat_hook.chat_owner_addr, timeout)
+            await self._wait_for_value(chat_hook.recv_counter, timeout)
 
     async def deactivate_chat_hook(self):
         """Deactivate the chat hook."""
@@ -622,7 +625,10 @@ class HookHandler(MemoryReader):
         await hook.unhook()
 
         del self._base_addrs["chat_owner"]
-        del self._base_addrs["chat_message"]
+        del self._base_addrs["recv_source_gid"]
+        del self._base_addrs["recv_message_buf"]
+        del self._base_addrs["recv_message_len"]
+        del self._base_addrs["recv_counter"]
 
     async def read_chat_owner_base(self) -> int:
         """Read the chat owner (chat module) base address.
@@ -631,14 +637,6 @@ class HookHandler(MemoryReader):
             The chat module base address
         """
         return await self._read_hook_base_addr("chat_owner", "Chat")
-
-    async def read_chat_message_base(self) -> int:
-        """Read the current DML message pointer (transient, only valid during handler).
-
-        Returns:
-            The current DML message base address
-        """
-        return await self._read_hook_base_addr("chat_message", "Chat")
 
     async def activate_chat_send_hook(self):
         """Activate the chat send hook on the main game loop.

--- a/wizwalker/memory/hooks.py
+++ b/wizwalker/memory/hooks.py
@@ -726,22 +726,25 @@ class MouselessCursorMoveHook(User32GetClassInfoBaseHook):
 
 
 class ChatHook(SimpleHook):
-    """Captures the chat module pointer when MSG_DirectedChat is processed.
+    """Captures incoming directed chat message data.
 
     Binary RE source: FUN_1416dbb30 (r794925) — MSG_DirectedChat handler.
 
-    At function entry:
-      RCX = chat owner object (the module that registered this handler)
-      RDX = DML game message (contains SourceID, SourceName, Message, etc.)
+    Hooks AFTER the handler has extracted all DML fields, at the point
+    where GetWideString just returned the Message wstring pointer in RAX
+    and SourceID is already stored at [RBP-0x80].
 
-    The hook captures the chat owner pointer so Python can access
-    the chat subsystem's state. It also captures the DML message
-    pointer for reading incoming message fields.
+    Hook point: func+0x379 (LEA RCX,[RBP-0x8], 4 bytes)
+    At this point:
+      RAX = pointer to std::wstring (Message from GetWideString)
+      [RBP-0x80] = SourceID (GID, 8 bytes)
+      RSI = chat owner object (saved from RCX at func entry)
 
-    Pattern matches a common prologue shared by ~10 handler functions.
-    Disambiguation: at func+0x7E only the DirectedChat handler has
-    MOV dword ptr [RBP-10h], 9 (C7 45 F0 09 00 00 00), which sets
-    a chat type discriminator field unique to this handler.
+    The hook copies SourceID and Message text to persistent exports
+    and increments a counter so Python can detect new messages.
+
+    Pattern: uses the function prologue (same as before) to find the
+    function, then hooks at func+0x379 instead of func+0x00.
     """
     pattern = (
         rb"\x48\x89\x5C\x24\x18"           # MOV [RSP+18h], RBX
@@ -757,11 +760,18 @@ class ChatHook(SimpleHook):
         rb"\x45\x33\xF6"                    # XOR R14D, R14D
     )
     exports = [
-        ("chat_owner_addr", 8),     # persistent: chat module pointer
-        ("chat_message_addr", 8),   # transient: current DML message pointer
+        ("chat_owner_addr", 8),        # persistent: chat owner (RSI)
+        ("recv_source_gid", 8),        # sender's GID
+        ("recv_message_buf", 160),     # message text (UTF-16LE, 80 wchars max)
+        ("recv_message_len", 8),       # wchar count
+        ("recv_counter", 8),           # increments on each message
     ]
-    instruction_length = 5
-    noops = 0
+    # Hook at func+0x379: LEA RCX,[RBP-0x8] (4 bytes) + CMP RCX,RAX (3 bytes)
+    # Both instructions must be replaced because a JMP is 5 bytes and
+    # the LEA is only 4 — the 5th byte would corrupt the CMP.
+    _HOOK_OFFSET = 0x379
+    instruction_length = 7   # 4 (LEA) + 3 (CMP) = 7 bytes
+    noops = 2                # 7 - 5 = 2 padding NOPs
 
     # The prologue pattern returns ~10 results from the pattern scan.
     # Of those ~10 results, only the DirectedChat handler has
@@ -782,7 +792,8 @@ class ChatHook(SimpleHook):
                 addr + self._DISAMBIG_OFFSET, len(self._DISAMBIG_BYTES)
             )
             if probe == self._DISAMBIG_BYTES:
-                return addr
+                # Hook at func+0x379, not at the prologue
+                return addr + self._HOOK_OFFSET
 
         from wizwalker import PatternFailed
         raise PatternFailed(
@@ -790,19 +801,112 @@ class ChatHook(SimpleHook):
             f"had type=9 marker at offset +{self._DISAMBIG_OFFSET:#x}"
         )
 
-    async def bytecode_generator(self, packed_exports):
-        # At entry: RCX = chat owner, RDX = DML message
-        # fmt: off
-        bytecode = (
-            b"\x50"                              # push rax
-            b"\x48\x89\xC8"                      # mov rax, rcx  (chat owner)
-            b"\x48\xA3" + packed_exports[0][1] + # mov [chat_owner_addr], rax
-            b"\x48\x89\xD0"                      # mov rax, rdx  (DML message)
-            b"\x48\xA3" + packed_exports[1][1] + # mov [chat_message_addr], rax
-            b"\x58"                              # pop rax
-            b"\x48\x89\x5C\x24\x18"             # original: MOV [RSP+18h], RBX
+    async def hook(self):
+        """Override to allocate enough space for the extraction bytecode."""
+        pattern, module = await self.get_pattern()
+
+        self.jump_address = await self.get_jump_address(pattern, module=module)
+        self.hook_address = await self.get_hook_address(200)
+
+        logger.debug(f"Got hook address {self.hook_address} in {type(self)}")
+        logger.debug(f"Got jump address {self.jump_address} in {type(self)}")
+
+        self.hook_bytecode = await self.get_hook_bytecode()
+        self.jump_bytecode = await self.get_jump_bytecode()
+
+        self.jump_original_bytecode = await self.read_bytes(
+            self.jump_address, len(self.jump_bytecode)
         )
+
+        await self.prehook()
+        await self.write_bytes(self.hook_address, self.hook_bytecode)
+        await self.write_bytes(self.jump_address, self.jump_bytecode)
+        await self.posthook()
+
+    async def bytecode_generator(self, packed_exports):
+        chat_owner  = packed_exports[0][1]
+        source_gid  = packed_exports[1][1]
+        message_buf = packed_exports[2][1]
+        message_len = packed_exports[3][1]
+        counter     = packed_exports[4][1]
+
+        # At hook point (func+0x379), register state:
+        #   RAX = wstring pointer (Message from GetWideString)
+        #   [RBP-0x80] = SourceID GID (8 bytes)
+        #   RSI = chat owner (saved from param_1 at func entry)
+
+        # fmt: off
+        preamble = (
+            # Save volatile registers
+            b"\x51"                              # push rcx
+            b"\x52"                              # push rdx
+            b"\x41\x50"                          # push r8
+            b"\x41\x51"                          # push r9
+
+            # RAX = wstring ptr from GetWideString
+
+            # Save chat owner (RSI → export)
+            b"\x50"                              # push rax
+            b"\x48\x89\xF0"                      # mov rax, rsi
+            b"\x48\xA3" + chat_owner +           # mov [chat_owner], rax
+            b"\x58"                              # pop rax
+
+            # Copy SourceID ([RBP-0x80] → export)
+            b"\x50"                              # push rax
+            b"\x48\x8B\x45\x80"                 # mov rax, [rbp-0x80]
+            b"\x48\xA3" + source_gid +           # mov [recv_source_gid], rax
+            b"\x58"                              # pop rax
+
+            # Save message length ([rax+0x10] → export)
+            b"\x50"                              # push rax
+            b"\x48\x8B\x40\x10"                 # mov rax, [rax+0x10]
+            b"\x48\xA3" + message_len +          # mov [recv_message_len], rax
+            b"\x58"                              # pop rax
+
+            # Get wstring data pointer into RDX
+            b"\x48\x8B\xD0"                      # mov rdx, rax (inline)
+            b"\x48\x83\x78\x18\x08"             # cmp [rax+0x18], 8
+            b"\x72\x03"                          # jb .copy
+            b"\x48\x8B\x10"                      # mov rdx, [rax] (heap)
+        )
+
+        # Copy 160 bytes (20 x 8-byte chunks) from RDX to export
+        # Use R8 as dest, R9 as counter, RCX as temp value
+        copy_loop = (
+            b"\x49\xB8" + message_buf +          # mov r8, &message_buf
+            b"\x41\xB9\x14\x00\x00\x00"         # mov r9d, 20 (iterations)
+            # .loop:
+            b"\x48\x8B\x0A"                      # mov rcx, [rdx]
+            b"\x49\x89\x08"                      # mov [r8], rcx
+            b"\x48\x83\xC2\x08"                 # add rdx, 8
+            b"\x49\x83\xC0\x08"                 # add r8, 8
+            b"\x41\xFF\xC9"                      # dec r9d
+            b"\x75\xED"                          # jnz .loop (-19 bytes back)
+        )
+
+        # Increment message counter
+        inc_counter = (
+            b"\x50"                              # push rax
+            b"\x48\xA1" + counter +              # mov rax, [recv_counter]
+            b"\x48\xFF\xC0"                      # inc rax
+            b"\x48\xA3" + counter +              # mov [recv_counter], rax
+            b"\x58"                              # pop rax
+        )
+
+        # Restore registers
+        restore = (
+            b"\x41\x59"                          # pop r9
+            b"\x41\x58"                          # pop r8
+            b"\x5A"                              # pop rdx
+            b"\x59"                              # pop rcx
+        )
+
+        # Original instructions: LEA RCX,[RBP-0x8] (4) + CMP RCX,RAX (3) = 7 bytes
+        original = await self.read_bytes(self.jump_address, 7)
+
+        bytecode = preamble + copy_loop + inc_counter + restore + original
         # fmt: on
+
         return bytecode
 
 

--- a/wizwalker/memory/hooks.py
+++ b/wizwalker/memory/hooks.py
@@ -807,26 +807,24 @@ class ChatHook(SimpleHook):
 
 
 class ChatSendHook(SimpleHook):
-    """Bidirectional hook for sending directed chat on the main thread.
+    """Main-thread action hook for social operations.
 
     Hooks the game's main loop at the shutdown_signal check:
       CMP [RDI+0x211B8], BL  (RDI = GameClient)
 
     This runs every frame on the main game thread. Each iteration
-    the hook checks a trigger flag. When Python sets the flag, the
-    hook calls the game's own send_directed_chat function
-    (FUN_1416e5ac0) with the struct data from the export buffer.
+    the hook checks trigger flags. When Python sets a trigger, the
+    hook calls the corresponding game function on the main thread
+    where UI updates and game state access are safe.
 
-    This is safe because it executes on the main thread where the
-    game expects chat operations to happen (UI updates, chat history,
-    buddy validation all work correctly).
+    Supported actions:
+      send_trigger=1  -> call send_directed_chat(GameClient, &send_struct)
+      buddy_trigger=1 -> call buddy_request_add(&buddy_obj)
 
-    Python writes:
-      1. The DirectedChatRequest struct to send_struct export
-      2. Sets send_trigger to 1
-    Then polls send_trigger until it becomes 0 (send complete).
+    Python writes data to the export buffer, sets the trigger to 1,
+    then polls until the hook clears it back to 0 (action complete).
 
-    Current limitation: messages must be <=7 wchars (SSO inline).
+    Current chat limitation: messages must be <=7 wchars (SSO inline).
     """
     # Pattern: shutdown_signal CMP in the main game loop, followed
     # by JZ (loop back), CALL, and CMP EAX,0x64 (return check).
@@ -838,11 +836,13 @@ class ChatSendHook(SimpleHook):
     instruction_length = 6  # CMP [RDI+offset], BL = 6 bytes
     noops = 0
     exports = [
-        ("send_trigger", 1),      # 1 = send requested, 0 = idle/done
-        ("send_struct", 0x28),    # DirectedChatRequest struct (40 bytes)
+        ("send_trigger", 1),      # chat: 1 = send requested, 0 = idle
+        ("send_struct", 0x28),    # chat: DirectedChatRequest (40 bytes)
+        ("buddy_trigger", 1),     # buddy: 1 = add requested, 0 = idle
+        ("buddy_obj", 0xE8),      # buddy: fake object, GID at +0xE0
     ]
 
-    # Send function pattern + disambiguation (same as chat_owner.py)
+    # --- Send directed chat function ---
     _SEND_PATTERN = (
         rb"\x48\x89\x5C\x24\x18"
         rb"\x55\x56\x57"
@@ -856,6 +856,27 @@ class ChatSendHook(SimpleHook):
     )
     _SEND_DISAMBIG_OFFSET = 0x33
     _SEND_DISAMBIG_BYTES = b"\x48\x83\xC2\x20"
+
+    # --- Buddy add function: FUN_141710e10 ---
+    # This is the clean buddy add that takes (BuddyListManager, target_gid).
+    # The key differentiator from FUN_1412536b0 (dialog callback) is
+    # MOV [RSP+20h], RDX at func+0x1E — it saves param_2 (the GID).
+    # FUN_1412536b0 doesn't have this instruction because it only
+    # takes one parameter.
+    _BUDDY_PATTERN = (
+        rb"\x48\x81\xEC\xA0\x00\x00\x00"       # SUB RSP, 0xA0
+        rb"\x48\x8B\x05...."                   # MOV RAX, [cookie]
+        rb"\x48\x33\xC4"                        # XOR RAX, RSP
+        rb"\x48\x89\x84\x24\x90\x00\x00\x00"  # MOV [RSP+90h], RAX
+        rb"\x48\x8B\xD9"                        # MOV RBX, RCX
+        rb"\x48\x89\x54\x24\x20"               # MOV [RSP+20h], RDX (saves param_2)
+        rb"\xBA\x10\x00\x00\x00"               # MOV EDX, 0x10
+        rb"\x48\x8D\x4C\x24\x30"               # LEA RCX, [RSP+30h]
+    )
+    # MOVUPS at func+0x72 loads "MSG_BUDDYREQUESTADD". Pattern starts
+    # at func+2 (skips PUSH RBX), so disambig offset is 0x72 - 2.
+    _BUDDY_DISAMBIG_OFFSET = 0x70
+    _BUDDY_DISAMBIG_BYTES = b"\x0F\x10\x05"
 
     async def _resolve_send_func(self) -> int:
         """Resolve FUN_1416e5ac0 via pattern scan + disambiguation."""
@@ -881,12 +902,55 @@ class ChatSendHook(SimpleHook):
             f"{len(candidates)} but none had ADD RDX,0x20"
         )
 
+    async def _resolve_buddy_add_func(self) -> int:
+        """Resolve FUN_141710e10 via pattern scan + string verification.
+
+        Multiple buddy functions (Add, Drop, etc.) share the same prologue
+        and all have MOVUPS at the same offset. We disambiguate by reading
+        the RIP-relative target of the MOVUPS and verifying it points to
+        the "MSG_BUDDYREQUESTADD" string (starts with 'M','S','G','_','B',
+        'U','D','D','Y','R','E','Q','U','E','S','T','A','D','D').
+        """
+        candidates = await self.pattern_scan(
+            self._BUDDY_PATTERN,
+            module="WizardGraphicalClient.exe",
+            return_multiple=True,
+        )
+        if isinstance(candidates, int):
+            candidates = [candidates]
+
+        for addr in candidates:
+            probe = await self.read_bytes(
+                addr + self._BUDDY_DISAMBIG_OFFSET,
+                len(self._BUDDY_DISAMBIG_BYTES),
+            )
+            if probe != self._BUDDY_DISAMBIG_BYTES:
+                continue
+
+            # Read the RIP-relative offset from the MOVUPS instruction.
+            # MOVUPS XMM0,[rip+disp32] = 0F 10 05 <disp32> (7 bytes)
+            movups_addr = addr + self._BUDDY_DISAMBIG_OFFSET
+            disp32_bytes = await self.read_bytes(movups_addr + 3, 4)
+            disp32 = struct.unpack("<i", disp32_bytes)[0]
+            string_addr = (movups_addr + 7) + disp32
+
+            # Verify it's "MSG_BUDDYREQUESTADD" (not DROP, ACCEPT, etc.)
+            string_bytes = await self.read_bytes(string_addr, 19)
+            if string_bytes == b"MSG_BUDDYREQUESTADD":
+                return addr - 2  # pattern starts at func+2
+
+        from wizwalker import PatternFailed
+        raise PatternFailed(
+            f"ChatSendHook: buddy add pattern matched "
+            f"{len(candidates)} but none loaded MSG_BUDDYREQUESTADD"
+        )
+
     async def hook(self):
         """Override to allocate enough space for the larger bytecode."""
         pattern, module = await self.get_pattern()
 
         self.jump_address = await self.get_jump_address(pattern, module=module)
-        self.hook_address = await self.get_hook_address(200)
+        self.hook_address = await self.get_hook_address(300)
 
         logger.debug(f"Got hook address {self.hook_address} in {type(self)}")
         logger.debug(f"Got jump address {self.jump_address} in {type(self)}")
@@ -903,25 +967,27 @@ class ChatSendHook(SimpleHook):
         await self.write_bytes(self.jump_address, self.jump_bytecode)
         await self.posthook()
 
-    async def bytecode_generator(self, packed_exports):
-        send_func = await self._resolve_send_func()
-        q = struct.pack("<Q", send_func)
-        trigger_addr = packed_exports[0][1]   # send_trigger
-        struct_addr = packed_exports[1][1]    # send_struct
+    def _build_action_block(self, trigger_addr, save_restore, call_setup, clear_trigger):
+        """Build a check-trigger + call + clear block with jz skip."""
+        # Check trigger
+        check = (
+            b"\x50"                              # push rax
+            b"\xA0" + trigger_addr +             # movabs al, [trigger]
+            b"\x84\xC0"                          # test al, al
+            b"\x58"                              # pop rax
+            b"\x0F\x84" + b"\x00\x00\x00\x00"   # jz skip (patch below)
+        )
+        body = save_restore + call_setup + clear_trigger
+        # Patch jz: skip over body
+        jz_offset = 13  # position of 0F 84 in check block
+        rel32 = len(body)
+        patched = bytearray(check)
+        struct.pack_into("<i", patched, jz_offset + 2, rel32)
+        return bytes(patched) + body
 
-        # Read the original CMP instruction bytes so we can replay them.
-        # CMP [RDI+offset], BL — 6 bytes at jump_address.
-        original_cmp = await self.read_bytes(self.jump_address, 6)
-
-        # fmt: off
-        bytecode = (
-            # --- Check trigger (13 bytes) ---
-            b"\x50"                              # push rax           [0]
-            b"\xA0" + trigger_addr +             # movabs al, [trig]  [1..9]
-            b"\x84\xC0"                          # test al, al        [10..11]
-            b"\x58"                              # pop rax             [12]
-            b"\x0F\x84" + b"\x00\x00\x00\x00" + # jz skip_send       [13..18]
-            # --- Save volatile registers ---
+    def _save_restore_regs(self, call_bytes, trigger_addr):
+        """Wrap a call with register save/restore and trigger clear."""
+        save = (
             b"\x50"                              # push rax
             b"\x51"                              # push rcx
             b"\x52"                              # push rdx
@@ -929,14 +995,10 @@ class ChatSendHook(SimpleHook):
             b"\x41\x51"                          # push r9
             b"\x41\x52"                          # push r10
             b"\x41\x53"                          # push r11
-            b"\x48\x81\xEC\x28\x00\x00\x00" +   # sub rsp, 0x28
-            # --- Call send_directed_chat(GameClient, &struct) ---
-            b"\x48\x89\xF9" +                   # mov rcx, rdi
-            b"\x48\xBA" + struct_addr +          # movabs rdx, send_struct
-            b"\x48\xB8" + q +                   # movabs rax, send_func
-            b"\xFF\xD0"                          # call rax
-            # --- Restore ---
-            b"\x48\x81\xC4\x28\x00\x00\x00" +   # add rsp, 0x28
+            b"\x48\x81\xEC\x28\x00\x00\x00"     # sub rsp, 0x28
+        )
+        restore = (
+            b"\x48\x81\xC4\x28\x00\x00\x00"     # add rsp, 0x28
             b"\x41\x5B"                          # pop r11
             b"\x41\x5A"                          # pop r10
             b"\x41\x59"                          # pop r9
@@ -944,24 +1006,58 @@ class ChatSendHook(SimpleHook):
             b"\x5A"                              # pop rdx
             b"\x59"                              # pop rcx
             b"\x58"                              # pop rax
-            # --- Clear trigger ---
+        )
+        clear = (
             b"\x50"                              # push rax
             b"\x30\xC0"                          # xor al, al
-            b"\xA2" + trigger_addr +             # movabs [trig], al
+            b"\xA2" + trigger_addr +             # movabs [trigger], al
             b"\x58"                              # pop rax
         )
-        # fmt: on
+        return save + call_bytes + restore, clear
 
-        # Patch jz rel32: the 0F 84 instruction starts at byte 13.
-        # rel32 is relative to the end of the jz instruction (byte 19).
-        jz_instr_offset = 13
-        skip_target = len(bytecode)
-        rel32 = skip_target - (jz_instr_offset + 6)
-        patched = bytearray(bytecode)
-        struct.pack_into("<i", patched, jz_instr_offset + 2, rel32)
-        bytecode = bytes(patched)
+    async def bytecode_generator(self, packed_exports):
+        send_func = await self._resolve_send_func()
+        buddy_func = await self._resolve_buddy_add_func()
 
-        # Append original CMP instruction
-        bytecode += original_cmp
+        send_trigger = packed_exports[0][1]
+        send_struct  = packed_exports[1][1]
+        buddy_trigger = packed_exports[2][1]
+        buddy_obj    = packed_exports[3][1]
 
+        original_cmp = await self.read_bytes(self.jump_address, 6)
+
+        q = lambda v: struct.pack("<Q", v)
+
+        # --- Action 1: send directed chat ---
+        chat_call = (
+            b"\x48\x89\xF9" +                   # mov rcx, rdi (GameClient)
+            b"\x48\xBA" + send_struct +          # movabs rdx, &send_struct
+            b"\x48\xB8" + q(send_func) +         # movabs rax, send_func
+            b"\xFF\xD0"                          # call rax
+        )
+        chat_body, chat_clear = self._save_restore_regs(chat_call, send_trigger)
+        chat_block = self._build_action_block(
+            send_trigger, chat_body, b"", chat_clear
+        )
+
+        # --- Action 2: buddy add ---
+        # FUN_141710e10(BuddyListManager, target_gid_value)
+        #   param_1 needs [+0x18] = GameClient pointer
+        #   param_2 = raw GID value (not a pointer)
+        # We use buddy_obj as a fake BuddyListManager, writing RDI
+        # (GameClient from the game loop) into [buddy_obj+0x18] at
+        # call time. The target GID was written by Python at +0xE0.
+        buddy_call = (
+            b"\x48\xB9" + buddy_obj +           # movabs rcx, &buddy_obj
+            b"\x48\x89\x79\x18" +               # mov [rcx+0x18], rdi  (GameClient)
+            b"\x48\x8B\x91\xE0\x00\x00\x00" +   # mov rdx, [rcx+0xE0]  (target GID)
+            b"\x48\xB8" + q(buddy_func) +        # movabs rax, buddy_func
+            b"\xFF\xD0"                          # call rax
+        )
+        buddy_body, buddy_clear = self._save_restore_regs(buddy_call, buddy_trigger)
+        buddy_block = self._build_action_block(
+            buddy_trigger, buddy_body, b"", buddy_clear
+        )
+
+        bytecode = chat_block + buddy_block + original_cmp
         return bytecode

--- a/wizwalker/memory/hooks.py
+++ b/wizwalker/memory/hooks.py
@@ -723,3 +723,245 @@ class MouselessCursorMoveHook(User32GetClassInfoBaseHook):
         if self.set_cursor_pos:
             set_cursor_pos, set_cursor_pos_bytes = self.set_cursor_pos
             await self.write_bytes(set_cursor_pos, set_cursor_pos_bytes)
+
+
+class ChatHook(SimpleHook):
+    """Captures the chat module pointer when MSG_DirectedChat is processed.
+
+    Binary RE source: FUN_1416dbb30 (r794925) — MSG_DirectedChat handler.
+
+    At function entry:
+      RCX = chat owner object (the module that registered this handler)
+      RDX = DML game message (contains SourceID, SourceName, Message, etc.)
+
+    The hook captures the chat owner pointer so Python can access
+    the chat subsystem's state. It also captures the DML message
+    pointer for reading incoming message fields.
+
+    Pattern matches a common prologue shared by ~10 handler functions.
+    Disambiguation: at func+0x7E only the DirectedChat handler has
+    MOV dword ptr [RBP-10h], 9 (C7 45 F0 09 00 00 00), which sets
+    a chat type discriminator field unique to this handler.
+    """
+    pattern = (
+        rb"\x48\x89\x5C\x24\x18"           # MOV [RSP+18h], RBX
+        rb"\x48\x89\x74\x24\x20"           # MOV [RSP+20h], RSI
+        rb"\x55\x57\x41\x56"               # PUSH RBP / PUSH RDI / PUSH R14
+        rb"\x48\x8D\xAC\x24\x40\xFF\xFF\xFF"  # LEA RBP, [RSP-0C0h]
+        rb"\x48\x81\xEC\xC0\x01\x00\x00"   # SUB RSP, 1C0h
+        rb"\x48\x8B\x05...."               # MOV RAX, [rip+??] (cookie)
+        rb"\x48\x33\xC4"                    # XOR RAX, RSP
+        rb"\x48\x89\x85\xB0\x00\x00\x00"   # MOV [RBP+0B0h], RAX
+        rb"\x48\x8B\xFA"                    # MOV RDI, RDX
+        rb"\x48\x8B\xF1"                    # MOV RSI, RCX
+        rb"\x45\x33\xF6"                    # XOR R14D, R14D
+    )
+    exports = [
+        ("chat_owner_addr", 8),     # persistent: chat module pointer
+        ("chat_message_addr", 8),   # transient: current DML message pointer
+    ]
+    instruction_length = 5
+    noops = 0
+
+    # The prologue pattern returns ~10 results from the pattern scan.
+    # Of those ~10 results, only the DirectedChat handler has
+    # MOV dword ptr [RBP-10h], 9 at func+0x7E. So we override
+    # get_jump_address to probe each match and find the correct one.
+    _DISAMBIG_OFFSET = 0x7E
+    _DISAMBIG_BYTES = b"\xC7\x45\xF0\x09\x00\x00\x00"
+
+    async def get_jump_address(self, pattern: bytes, module: str = None) -> int:
+        candidates = await self.pattern_scan(
+            pattern, module=module, return_multiple=True
+        )
+        if isinstance(candidates, int):
+            candidates = [candidates]
+
+        for addr in candidates:
+            probe = await self.read_bytes(
+                addr + self._DISAMBIG_OFFSET, len(self._DISAMBIG_BYTES)
+            )
+            if probe == self._DISAMBIG_BYTES:
+                return addr
+
+        from wizwalker import PatternFailed
+        raise PatternFailed(
+            f"ChatHook: pattern matched {len(candidates)} functions but none "
+            f"had type=9 marker at offset +{self._DISAMBIG_OFFSET:#x}"
+        )
+
+    async def bytecode_generator(self, packed_exports):
+        # At entry: RCX = chat owner, RDX = DML message
+        # fmt: off
+        bytecode = (
+            b"\x50"                              # push rax
+            b"\x48\x89\xC8"                      # mov rax, rcx  (chat owner)
+            b"\x48\xA3" + packed_exports[0][1] + # mov [chat_owner_addr], rax
+            b"\x48\x89\xD0"                      # mov rax, rdx  (DML message)
+            b"\x48\xA3" + packed_exports[1][1] + # mov [chat_message_addr], rax
+            b"\x58"                              # pop rax
+            b"\x48\x89\x5C\x24\x18"             # original: MOV [RSP+18h], RBX
+        )
+        # fmt: on
+        return bytecode
+
+
+class ChatSendHook(SimpleHook):
+    """Bidirectional hook for sending directed chat on the main thread.
+
+    Hooks the game's main loop at the shutdown_signal check:
+      CMP [RDI+0x211B8], BL  (RDI = GameClient)
+
+    This runs every frame on the main game thread. Each iteration
+    the hook checks a trigger flag. When Python sets the flag, the
+    hook calls the game's own send_directed_chat function
+    (FUN_1416e5ac0) with the struct data from the export buffer.
+
+    This is safe because it executes on the main thread where the
+    game expects chat operations to happen (UI updates, chat history,
+    buddy validation all work correctly).
+
+    Python writes:
+      1. The DirectedChatRequest struct to send_struct export
+      2. Sets send_trigger to 1
+    Then polls send_trigger until it becomes 0 (send complete).
+
+    Current limitation: messages must be <=7 wchars (SSO inline).
+    """
+    # Pattern: shutdown_signal CMP in the main game loop, followed
+    # by JZ (loop back), CALL, and CMP EAX,0x64 (return check).
+    # The displacement in the CMP and the JZ offset are wildcarded
+    # for patch survivability.
+    pattern = (
+        rb"\x38\x9F....\x74.\xE8....\x83\xF8\x64\x0F\x8F"
+    )
+    instruction_length = 6  # CMP [RDI+offset], BL = 6 bytes
+    noops = 0
+    exports = [
+        ("send_trigger", 1),      # 1 = send requested, 0 = idle/done
+        ("send_struct", 0x28),    # DirectedChatRequest struct (40 bytes)
+    ]
+
+    # Send function pattern + disambiguation (same as chat_owner.py)
+    _SEND_PATTERN = (
+        rb"\x48\x89\x5C\x24\x18"
+        rb"\x55\x56\x57"
+        rb"\x48\x8D\xAC\x24\x30\xFF\xFF\xFF"
+        rb"\x48\x81\xEC\xD0\x01\x00\x00"
+        rb"\x48\x8B\x05...."
+        rb"\x48\x33\xC4"
+        rb"\x48\x89\x85\xC0\x00\x00\x00"
+        rb"\x48\x8B\xDA"
+        rb"\x48\x8B\xF9"
+    )
+    _SEND_DISAMBIG_OFFSET = 0x33
+    _SEND_DISAMBIG_BYTES = b"\x48\x83\xC2\x20"
+
+    async def _resolve_send_func(self) -> int:
+        """Resolve FUN_1416e5ac0 via pattern scan + disambiguation."""
+        candidates = await self.pattern_scan(
+            self._SEND_PATTERN,
+            module="WizardGraphicalClient.exe",
+            return_multiple=True,
+        )
+        if isinstance(candidates, int):
+            candidates = [candidates]
+
+        for addr in candidates:
+            probe = await self.read_bytes(
+                addr + self._SEND_DISAMBIG_OFFSET,
+                len(self._SEND_DISAMBIG_BYTES),
+            )
+            if probe == self._SEND_DISAMBIG_BYTES:
+                return addr
+
+        from wizwalker import PatternFailed
+        raise PatternFailed(
+            f"ChatSendHook: send function pattern matched "
+            f"{len(candidates)} but none had ADD RDX,0x20"
+        )
+
+    async def hook(self):
+        """Override to allocate enough space for the larger bytecode."""
+        pattern, module = await self.get_pattern()
+
+        self.jump_address = await self.get_jump_address(pattern, module=module)
+        self.hook_address = await self.get_hook_address(200)
+
+        logger.debug(f"Got hook address {self.hook_address} in {type(self)}")
+        logger.debug(f"Got jump address {self.jump_address} in {type(self)}")
+
+        self.hook_bytecode = await self.get_hook_bytecode()
+        self.jump_bytecode = await self.get_jump_bytecode()
+
+        self.jump_original_bytecode = await self.read_bytes(
+            self.jump_address, len(self.jump_bytecode)
+        )
+
+        await self.prehook()
+        await self.write_bytes(self.hook_address, self.hook_bytecode)
+        await self.write_bytes(self.jump_address, self.jump_bytecode)
+        await self.posthook()
+
+    async def bytecode_generator(self, packed_exports):
+        send_func = await self._resolve_send_func()
+        q = struct.pack("<Q", send_func)
+        trigger_addr = packed_exports[0][1]   # send_trigger
+        struct_addr = packed_exports[1][1]    # send_struct
+
+        # Read the original CMP instruction bytes so we can replay them.
+        # CMP [RDI+offset], BL — 6 bytes at jump_address.
+        original_cmp = await self.read_bytes(self.jump_address, 6)
+
+        # fmt: off
+        bytecode = (
+            # --- Check trigger (13 bytes) ---
+            b"\x50"                              # push rax           [0]
+            b"\xA0" + trigger_addr +             # movabs al, [trig]  [1..9]
+            b"\x84\xC0"                          # test al, al        [10..11]
+            b"\x58"                              # pop rax             [12]
+            b"\x0F\x84" + b"\x00\x00\x00\x00" + # jz skip_send       [13..18]
+            # --- Save volatile registers ---
+            b"\x50"                              # push rax
+            b"\x51"                              # push rcx
+            b"\x52"                              # push rdx
+            b"\x41\x50"                          # push r8
+            b"\x41\x51"                          # push r9
+            b"\x41\x52"                          # push r10
+            b"\x41\x53"                          # push r11
+            b"\x48\x81\xEC\x28\x00\x00\x00" +   # sub rsp, 0x28
+            # --- Call send_directed_chat(GameClient, &struct) ---
+            b"\x48\x89\xF9" +                   # mov rcx, rdi
+            b"\x48\xBA" + struct_addr +          # movabs rdx, send_struct
+            b"\x48\xB8" + q +                   # movabs rax, send_func
+            b"\xFF\xD0"                          # call rax
+            # --- Restore ---
+            b"\x48\x81\xC4\x28\x00\x00\x00" +   # add rsp, 0x28
+            b"\x41\x5B"                          # pop r11
+            b"\x41\x5A"                          # pop r10
+            b"\x41\x59"                          # pop r9
+            b"\x41\x58"                          # pop r8
+            b"\x5A"                              # pop rdx
+            b"\x59"                              # pop rcx
+            b"\x58"                              # pop rax
+            # --- Clear trigger ---
+            b"\x50"                              # push rax
+            b"\x30\xC0"                          # xor al, al
+            b"\xA2" + trigger_addr +             # movabs [trig], al
+            b"\x58"                              # pop rax
+        )
+        # fmt: on
+
+        # Patch jz rel32: the 0F 84 instruction starts at byte 13.
+        # rel32 is relative to the end of the jz instruction (byte 19).
+        jz_instr_offset = 13
+        skip_target = len(bytecode)
+        rel32 = skip_target - (jz_instr_offset + 6)
+        patched = bytearray(bytecode)
+        struct.pack_into("<i", patched, jz_instr_offset + 2, rel32)
+        bytecode = bytes(patched)
+
+        # Append original CMP instruction
+        bytecode += original_cmp
+
+        return bytecode

--- a/wizwalker/memory/memory_objects/__init__.py
+++ b/wizwalker/memory/memory_objects/__init__.py
@@ -1,4 +1,11 @@
 from .actor_body import ActorBody, CurrentActorBody, DynamicActorBody
+from .basic_chat_channel_info import (
+    BasicChatChannelInfo,
+    DynamicBasicChatChannelInfo,
+)
+from .basic_chat_player import BasicChatPlayer, DynamicBasicChatPlayer
+from .chat_owner import ChatOwner, CurrentChatOwner, DynamicChatOwner
+from .guild_chat_info import GuildChatInfo, DynamicGuildChatInfo
 from .client_zone import ClientZone, DynamicClientZone
 from .client_object import (
     ClientObject,

--- a/wizwalker/memory/memory_objects/basic_chat_channel_info.py
+++ b/wizwalker/memory/memory_objects/basic_chat_channel_info.py
@@ -1,0 +1,50 @@
+from typing import List, Optional
+
+from wizwalker.memory.memory_object import DynamicMemoryObject, PropertyClass
+from wizwalker.constants import Primitive
+from .basic_chat_player import DynamicBasicChatPlayer
+
+
+# C++ class: BasicChatChannelInfo
+# PropertyClass subclass (type hash: 2121388742)
+# Source: type dump r794925_Wizard_1_600.json
+#
+# Class layout:
+# ==============================================
+# Offset  Type                                Description
+# ------  ----                                -----------
+# 0x000   PropertyClass                       Base (vtable + type info)
+# 0x048   gid (uint64)                        Owner character GID
+# 0x050   std::string                         Owner name blob
+# 0x070   bool                                Is public channel
+# 0x074   int32                               Invite-all cooldown time
+# 0x078   std::list<shared_ptr<BasicChatPlayer>>  Player list
+
+
+class BasicChatChannelInfo(PropertyClass):
+    async def read_base_address(self) -> int:
+        raise NotImplementedError()
+
+    async def owner_character_id(self) -> int:
+        """Owner character GID at offset 0x48."""
+        return await self.read_value_from_offset(0x48, Primitive.uint64)
+
+    async def owner_name_blob(self) -> str:
+        """Owner packed/encoded name at offset 0x50."""
+        return await self.read_string_from_offset(0x50)
+
+    async def is_public(self) -> bool:
+        """Whether this is a public channel at offset 0x70."""
+        return await self.read_value_from_offset(0x70, Primitive.bool)
+
+    async def invite_all_cooldown_time(self) -> int:
+        """Invite-all cooldown in seconds at offset 0x74."""
+        return await self.read_value_from_offset(0x74, Primitive.int32)
+
+    async def player_list(self) -> List[DynamicBasicChatPlayer]:
+        """List of BasicChatPlayer members in this channel at offset 0x78."""
+        return await self.read_shared_linked_list(0x78)
+
+
+class DynamicBasicChatChannelInfo(DynamicMemoryObject, BasicChatChannelInfo):
+    pass

--- a/wizwalker/memory/memory_objects/basic_chat_player.py
+++ b/wizwalker/memory/memory_objects/basic_chat_player.py
@@ -1,0 +1,52 @@
+from wizwalker.memory.memory_object import DynamicMemoryObject, PropertyClass
+from wizwalker.constants import Primitive
+
+
+# C++ class: BasicChatPlayer
+# PropertyClass subclass (type hash: 101684154)
+# Source: type dump r794925_Wizard_1_600.json
+#
+# Class layout:
+# ==============================================
+# Offset  Type            Description
+# ------  ----            -----------
+# 0x000   PropertyClass   Base (vtable + type info)
+# 0x048   gid (uint64)    Character GID
+# 0x050   std::string     Name blob (packed/encoded name)
+# 0x070   uint32          School + level composite
+# 0x078   gid (uint64)    Object ID (in-world entity ID)
+# 0x080   char (int8)     Platform type
+# 0x081   bool            Disable cross-play flag
+
+
+class BasicChatPlayer(PropertyClass):
+    async def read_base_address(self) -> int:
+        raise NotImplementedError()
+
+    async def character_id(self) -> int:
+        """Character GID at offset 72 (0x48)."""
+        return await self.read_value_from_offset(0x48, Primitive.uint64)
+
+    async def name_blob(self) -> str:
+        """Packed/encoded player name at offset 80 (0x50)."""
+        return await self.read_string_from_offset(0x50)
+
+    async def school_level(self) -> int:
+        """School+level composite at offset 112 (0x70)."""
+        return await self.read_value_from_offset(0x70, Primitive.uint32)
+
+    async def object_id(self) -> int:
+        """In-world object ID at offset 120 (0x78)."""
+        return await self.read_value_from_offset(0x78, Primitive.uint64)
+
+    async def platform_type(self) -> int:
+        """Platform type at offset 128 (0x80)."""
+        return await self.read_value_from_offset(0x80, Primitive.int8)
+
+    async def disable_cross_play(self) -> bool:
+        """Cross-play disabled flag at offset 129 (0x81)."""
+        return await self.read_value_from_offset(0x81, Primitive.bool)
+
+
+class DynamicBasicChatPlayer(DynamicMemoryObject, BasicChatPlayer):
+    pass

--- a/wizwalker/memory/memory_objects/chat_owner.py
+++ b/wizwalker/memory/memory_objects/chat_owner.py
@@ -187,6 +187,92 @@ class ChatOwner(MemoryObject):
 
         raise RuntimeError("Chat send timed out — trigger was not cleared by hook")
 
+    async def recv_message(self):
+        """Read the last received directed chat message.
+
+        Returns the sender GID, message text, and message counter.
+        The counter increments each time a new whisper arrives,
+        allowing callers to detect new messages by comparing against
+        a previously stored counter value.
+
+        Requires ChatHook to be active.
+
+        Returns:
+            Tuple of (sender_gid: int, message: str, counter: int)
+
+        Raises:
+            RuntimeError: If ChatHook is not active or no message received yet
+        """
+        gid_addr = self.hook_handler._base_addrs.get("recv_source_gid")
+        buf_addr = self.hook_handler._base_addrs.get("recv_message_buf")
+        len_addr = self.hook_handler._base_addrs.get("recv_message_len")
+        cnt_addr = self.hook_handler._base_addrs.get("recv_counter")
+        if any(a is None for a in (gid_addr, buf_addr, len_addr, cnt_addr)):
+            raise RuntimeError(
+                "ChatHook not active. Call "
+                "hook_handler.activate_chat_hook() first."
+            )
+
+        counter_bytes = await self.hook_handler.read_bytes(cnt_addr, 8)
+        counter = struct.unpack("<Q", counter_bytes)[0]
+        if counter == 0:
+            raise RuntimeError("No message received yet")
+
+        gid_bytes = await self.hook_handler.read_bytes(gid_addr, 8)
+        sender_gid = struct.unpack("<Q", gid_bytes)[0]
+
+        len_bytes = await self.hook_handler.read_bytes(len_addr, 8)
+        wchar_count = struct.unpack("<Q", len_bytes)[0]
+
+        # Read the message text (UTF-16LE), capped at export buffer size
+        byte_count = min(wchar_count * 2, 160)
+        msg_bytes = await self.hook_handler.read_bytes(buf_addr, byte_count)
+        message = msg_bytes.decode("utf-16-le", errors="replace")
+
+        return sender_gid, message, counter
+
+    async def wait_for_message(self, timeout: float = 10.0):
+        """Wait for a new directed chat message to arrive.
+
+        Polls the message counter until it changes from its current value,
+        indicating a new message was received.
+
+        Args:
+            timeout: Max seconds to wait (default 10)
+
+        Returns:
+            Tuple of (sender_gid: int, message: str, counter: int)
+
+        Raises:
+            RuntimeError: If ChatHook is not active
+            asyncio.TimeoutError: If no message arrives within timeout
+        """
+        cnt_addr = self.hook_handler._base_addrs.get("recv_counter")
+        if cnt_addr is None:
+            raise RuntimeError(
+                "ChatHook not active. Call "
+                "hook_handler.activate_chat_hook() first."
+            )
+
+        # Read current counter
+        counter_bytes = await self.hook_handler.read_bytes(cnt_addr, 8)
+        old_counter = struct.unpack("<Q", counter_bytes)[0]
+
+        # Poll until counter changes
+        elapsed = 0.0
+        interval = 0.05
+        while elapsed < timeout:
+            await asyncio.sleep(interval)
+            elapsed += interval
+            counter_bytes = await self.hook_handler.read_bytes(cnt_addr, 8)
+            new_counter = struct.unpack("<Q", counter_bytes)[0]
+            if new_counter != old_counter:
+                return await self.recv_message()
+
+        raise asyncio.TimeoutError(
+            f"No message received within {timeout} seconds"
+        )
+
     async def add_player(self, target_gid: int):
         """Send a buddy/friend request to a player.
 

--- a/wizwalker/memory/memory_objects/chat_owner.py
+++ b/wizwalker/memory/memory_objects/chat_owner.py
@@ -2,8 +2,12 @@ import asyncio
 import struct
 
 from wizwalker.memory.memory_object import MemoryObject, DynamicMemoryObject
-from wizwalker.constants import Primitive
 
+
+# The buddy add function (FUN_141710e10) receives the target GID as
+# param_2 (a raw value). The hook stores it at buddy_obj+0xE0 and
+# reads it back into RDX before calling the function.
+_BUDDY_GID_OFFSET = 0xE0
 
 # DirectedChatRequest struct layout (param_2 of FUN_1416e5ac0):
 #
@@ -20,10 +24,9 @@ _MAX_SSO_WCHARS = 7
 class ChatOwner(MemoryObject):
     """The chat module object captured by ChatHook.
 
-    Provides send_msg() to whisper another player. The send executes
-    on the game's main thread via ChatSendHook, which calls the game's
-    own FUN_1416e5ac0 — keeping all validation, filtering, buddy checks,
-    and UI updates intact.
+    Provides send_msg() to whisper another player and add_player()
+    to send a buddy request. Both execute on the game's main thread
+    via ChatSendHook, calling the game's own validated functions.
     """
 
     async def read_base_address(self) -> int:
@@ -82,6 +85,46 @@ class ChatOwner(MemoryObject):
 
         raise RuntimeError("Chat send timed out — trigger was not cleared by hook")
 
+    async def add_player(self, target_gid: int):
+        """Send a buddy/friend request to a player.
+
+        Writes the target GID to the ChatSendHook's buddy_obj export
+        at offset 0xE0, then sets buddy_trigger. The main-thread hook
+        reads the GID, sets up a fake BuddyListManager with the
+        GameClient pointer, and calls FUN_141710e10.
+
+        Args:
+            target_gid: The target player's GID to send a friend request to
+
+        Raises:
+            RuntimeError: If ChatSendHook is not active
+        """
+        trigger_addr = self.hook_handler._base_addrs.get("buddy_trigger")
+        obj_addr = self.hook_handler._base_addrs.get("buddy_obj")
+        if trigger_addr is None or obj_addr is None:
+            raise RuntimeError(
+                "ChatSendHook not active. Call "
+                "hook_handler.activate_chat_send_hook() first."
+            )
+
+        # Write target GID at offset 0xE0 in the buddy_obj export.
+        await self.hook_handler.write_bytes(
+            obj_addr + _BUDDY_GID_OFFSET,
+            struct.pack("<Q", target_gid),
+        )
+
+        # Set trigger — the main thread hook picks this up next frame
+        await self.hook_handler.write_bytes(trigger_addr, b"\x01")
+
+        # Wait for the hook to clear the trigger
+        for _ in range(100):
+            await asyncio.sleep(0.05)
+            result = await self.hook_handler.read_bytes(trigger_addr, 1)
+            if result == b"\x00":
+                return
+
+        raise RuntimeError("Buddy add timed out — trigger was not cleared by hook")
+
 
 class DynamicChatOwner(DynamicMemoryObject, ChatOwner):
     pass
@@ -90,9 +133,9 @@ class DynamicChatOwner(DynamicMemoryObject, ChatOwner):
 class CurrentChatOwner(ChatOwner):
     """Reads the chat owner address from the ChatHook export.
 
-    Note: send_msg() does not require ChatHook — it uses
-    ChatSendHook + the GameClient from ClientHook instead.
-    The ChatHook is only needed for reading incoming message data.
+    Note: send_msg() and add_player() do not require ChatHook — they
+    use ChatSendHook instead. The ChatHook is only needed for reading
+    incoming message data.
     """
 
     async def read_base_address(self) -> int:

--- a/wizwalker/memory/memory_objects/chat_owner.py
+++ b/wizwalker/memory/memory_objects/chat_owner.py
@@ -18,7 +18,15 @@ _BUDDY_GID_OFFSET = 0xE0
 #   0x18  uint64 capacity   (<=7 means SSO inline, >7 means heap ptr at 0x00)
 #   0x20  uint64 target_id  (GID)
 _STRUCT_SIZE = 0x28
-_MAX_SSO_WCHARS = 7
+
+# The game allows messages longer than 79 characters but when the
+# server relays that message to another client it looks to be capped
+# at 79 characters.
+_MAX_MESSAGE_WCHARS = 79
+
+# Offset from the send_directed_chat function (FUN_1416e5ac0) start
+# to the CALL operator_new instruction (E8 <rel32>).
+_OPERATOR_NEW_CALL_OFFSET = 0xF4
 
 
 class ChatOwner(MemoryObject):
@@ -32,6 +40,86 @@ class ChatOwner(MemoryObject):
     async def read_base_address(self) -> int:
         raise NotImplementedError()
 
+    async def _resolve_operator_new(self) -> int:
+        """Resolve the game's operator new address, cached.
+
+        Extracted from the CALL at send_func + 0xF4 inside
+        FUN_1416e5ac0. This is the same allocator the game uses
+        for SSO heap strings, so operator delete can safely free it.
+        """
+        cache_key = "_operator_new_addr"
+        cached = getattr(self.hook_handler, cache_key, None)
+        if cached is not None:
+            return cached
+
+        # Get the send function address from the ChatSendHook
+        from wizwalker.memory.hooks import ChatSendHook
+        hook = self.hook_handler._active_hooks.get(ChatSendHook)
+        if hook is None:
+            raise RuntimeError("ChatSendHook not active")
+
+        send_func = await hook._resolve_send_func()
+
+        # Read the E8 rel32 CALL at send_func + 0xF4
+        call_addr = send_func + _OPERATOR_NEW_CALL_OFFSET
+        rel32_bytes = await self.hook_handler.read_bytes(call_addr + 1, 4)
+        rel32 = struct.unpack("<i", rel32_bytes)[0]
+        operator_new = call_addr + 5 + rel32
+
+        setattr(self.hook_handler, cache_key, operator_new)
+        return operator_new
+
+    async def _alloc_game_heap(self, size: int) -> int:
+        """Allocate memory using the game's operator new.
+
+        This memory can be safely freed by the game's operator delete
+        (used by the wstring destructor). Uses a minimal internal
+        helper executed via start_thread.
+
+        Args:
+            size: Number of bytes to allocate
+
+        Returns:
+            Address of the allocated buffer in the game process
+        """
+        operator_new = await self._resolve_operator_new()
+
+        # Allocate a slot to receive the result pointer
+        result_addr = await self.hook_handler.allocate(8)
+
+        # Build a minimal helper:
+        #   sub rsp, 0x28       ; shadow space + alignment
+        #   mov ecx, <size>     ; param for operator new
+        #   mov rax, <op_new>   ; operator new address
+        #   call rax            ; rax = allocated buffer
+        #   mov [result], rax   ; store result
+        #   add rsp, 0x28
+        #   ret
+        q = lambda v: struct.pack("<Q", v)
+        helper = (
+            b"\x48\x81\xEC\x28\x00\x00\x00"
+            b"\xB9" + struct.pack("<I", size) +
+            b"\x48\xB8" + q(operator_new) +
+            b"\xFF\xD0"
+            b"\x48\xA3" + q(result_addr) +
+            b"\x48\x81\xC4\x28\x00\x00\x00"
+            b"\xC3"
+        )
+
+        helper_addr = await self.hook_handler.allocate(len(helper))
+        await self.hook_handler.write_bytes(helper_addr, helper)
+
+        try:
+            await self.hook_handler.start_thread(helper_addr)
+            result_bytes = await self.hook_handler.read_bytes(result_addr, 8)
+            heap_ptr = struct.unpack("<Q", result_bytes)[0]
+            if heap_ptr == 0:
+                raise RuntimeError("operator new returned NULL")
+            return heap_ptr
+        finally:
+            await self.hook_handler.free(helper_addr)
+            await self.hook_handler.free(result_addr)
+
     async def send_msg(self, message: str, target_gid: int):
         """Send a directed chat (whisper) to a player.
 
@@ -40,19 +128,25 @@ class ChatOwner(MemoryObject):
         main thread each frame) picks it up and calls the game's own
         send_directed_chat function.
 
+        For messages <= 7 characters, the wstring is stored inline (SSO).
+        For longer messages, a heap buffer is allocated using the game's
+        own operator new so the destructor can safely free it.
+
         Args:
-            message: The chat message text (max 7 characters for now)
+            message: The chat message text
             target_gid: The target player's GID
 
         Raises:
-            ValueError: If message exceeds 7 characters
+            ValueError: If message exceeds max length
             RuntimeError: If ChatSendHook is not active
         """
-        if len(message) > _MAX_SSO_WCHARS:
+        if len(message) > _MAX_MESSAGE_WCHARS:
             raise ValueError(
-                f"Message too long ({len(message)} chars, max {_MAX_SSO_WCHARS}). "
-                f"Longer messages require heap-allocated wstrings (not yet implemented)."
+                f"Message too long ({len(message)} chars, max {_MAX_MESSAGE_WCHARS})"
             )
+
+        if not message:
+            raise ValueError("Message cannot be empty")
 
         trigger_addr = self.hook_handler._base_addrs.get("send_trigger")
         struct_addr = self.hook_handler._base_addrs.get("send_struct")
@@ -62,13 +156,20 @@ class ChatOwner(MemoryObject):
                 "hook_handler.activate_chat_send_hook() first."
             )
 
-        # Build the DirectedChatRequest struct
         wchars = message.encode("utf-16-le")
+        wchar_count = len(message)
+
+        # Allocate the wstring buffer via the game's operator new so
+        # the destructor can safely call operator delete after send.
+        heap_ptr = await self._alloc_game_heap(len(wchars) + 2)
+        await self.hook_handler.write_bytes(heap_ptr, wchars + b"\x00\x00")
+
+        # Build the DirectedChatRequest struct
         struct_data = bytearray(_STRUCT_SIZE)
-        struct_data[0x00:0x00 + len(wchars)] = wchars   # inline SSO
-        struct.pack_into("<Q", struct_data, 0x10, len(message))  # size
-        struct.pack_into("<Q", struct_data, 0x18, 7)             # capacity (SSO)
-        struct.pack_into("<Q", struct_data, 0x20, target_gid)    # target GID
+        struct.pack_into("<Q", struct_data, 0x00, heap_ptr)
+        struct.pack_into("<Q", struct_data, 0x10, wchar_count)
+        struct.pack_into("<Q", struct_data, 0x18, wchar_count)
+        struct.pack_into("<Q", struct_data, 0x20, target_gid)
 
         # Write struct to the hook's export buffer
         await self.hook_handler.write_bytes(struct_addr, bytes(struct_data))
@@ -76,7 +177,8 @@ class ChatOwner(MemoryObject):
         # Set trigger — the main thread hook picks this up next frame
         await self.hook_handler.write_bytes(trigger_addr, b"\x01")
 
-        # Wait for the hook to clear the trigger (send complete)
+        # Wait for the hook to clear the trigger (send complete).
+        # The game's destructor handles freeing any heap buffer.
         for _ in range(100):  # ~5 seconds at 20 FPS
             await asyncio.sleep(0.05)
             result = await self.hook_handler.read_bytes(trigger_addr, 1)

--- a/wizwalker/memory/memory_objects/chat_owner.py
+++ b/wizwalker/memory/memory_objects/chat_owner.py
@@ -1,0 +1,99 @@
+import asyncio
+import struct
+
+from wizwalker.memory.memory_object import MemoryObject, DynamicMemoryObject
+from wizwalker.constants import Primitive
+
+
+# DirectedChatRequest struct layout (param_2 of FUN_1416e5ac0):
+#
+# MSVC x64 std::wstring (32 bytes) + target GID (8 bytes) = 40 bytes
+#
+#   0x00  union { wchar_t buf[8]; wchar_t* ptr; }  (16 bytes)
+#   0x10  uint64 size       (wchar count)
+#   0x18  uint64 capacity   (<=7 means SSO inline, >7 means heap ptr at 0x00)
+#   0x20  uint64 target_id  (GID)
+_STRUCT_SIZE = 0x28
+_MAX_SSO_WCHARS = 7
+
+
+class ChatOwner(MemoryObject):
+    """The chat module object captured by ChatHook.
+
+    Provides send_msg() to whisper another player. The send executes
+    on the game's main thread via ChatSendHook, which calls the game's
+    own FUN_1416e5ac0 — keeping all validation, filtering, buddy checks,
+    and UI updates intact.
+    """
+
+    async def read_base_address(self) -> int:
+        raise NotImplementedError()
+
+    async def send_msg(self, message: str, target_gid: int):
+        """Send a directed chat (whisper) to a player.
+
+        The message is written to the ChatSendHook's export buffer,
+        then a trigger flag is set. The hook (running on the game's
+        main thread each frame) picks it up and calls the game's own
+        send_directed_chat function.
+
+        Args:
+            message: The chat message text (max 7 characters for now)
+            target_gid: The target player's GID
+
+        Raises:
+            ValueError: If message exceeds 7 characters
+            RuntimeError: If ChatSendHook is not active
+        """
+        if len(message) > _MAX_SSO_WCHARS:
+            raise ValueError(
+                f"Message too long ({len(message)} chars, max {_MAX_SSO_WCHARS}). "
+                f"Longer messages require heap-allocated wstrings (not yet implemented)."
+            )
+
+        trigger_addr = self.hook_handler._base_addrs.get("send_trigger")
+        struct_addr = self.hook_handler._base_addrs.get("send_struct")
+        if trigger_addr is None or struct_addr is None:
+            raise RuntimeError(
+                "ChatSendHook not active. Call "
+                "hook_handler.activate_chat_send_hook() first."
+            )
+
+        # Build the DirectedChatRequest struct
+        wchars = message.encode("utf-16-le")
+        struct_data = bytearray(_STRUCT_SIZE)
+        struct_data[0x00:0x00 + len(wchars)] = wchars   # inline SSO
+        struct.pack_into("<Q", struct_data, 0x10, len(message))  # size
+        struct.pack_into("<Q", struct_data, 0x18, 7)             # capacity (SSO)
+        struct.pack_into("<Q", struct_data, 0x20, target_gid)    # target GID
+
+        # Write struct to the hook's export buffer
+        await self.hook_handler.write_bytes(struct_addr, bytes(struct_data))
+
+        # Set trigger — the main thread hook picks this up next frame
+        await self.hook_handler.write_bytes(trigger_addr, b"\x01")
+
+        # Wait for the hook to clear the trigger (send complete)
+        for _ in range(100):  # ~5 seconds at 20 FPS
+            await asyncio.sleep(0.05)
+            result = await self.hook_handler.read_bytes(trigger_addr, 1)
+            if result == b"\x00":
+                return
+
+        raise RuntimeError("Chat send timed out — trigger was not cleared by hook")
+
+
+class DynamicChatOwner(DynamicMemoryObject, ChatOwner):
+    pass
+
+
+class CurrentChatOwner(ChatOwner):
+    """Reads the chat owner address from the ChatHook export.
+
+    Note: send_msg() does not require ChatHook — it uses
+    ChatSendHook + the GameClient from ClientHook instead.
+    The ChatHook is only needed for reading incoming message data.
+    """
+
+    async def read_base_address(self) -> int:
+        return await self.hook_handler.read_chat_owner_base()

--- a/wizwalker/memory/memory_objects/chat_owner.py
+++ b/wizwalker/memory/memory_objects/chat_owner.py
@@ -164,11 +164,13 @@ class ChatOwner(MemoryObject):
         heap_ptr = await self._alloc_game_heap(len(wchars) + 2)
         await self.hook_handler.write_bytes(heap_ptr, wchars + b"\x00\x00")
 
-        # Build the DirectedChatRequest struct
+        # Build the DirectedChatRequest struct.
+        # Capacity must be > 7 so the game reads from the heap pointer
+        # at offset 0x00 instead of treating it as inline SSO data.
         struct_data = bytearray(_STRUCT_SIZE)
         struct.pack_into("<Q", struct_data, 0x00, heap_ptr)
         struct.pack_into("<Q", struct_data, 0x10, wchar_count)
-        struct.pack_into("<Q", struct_data, 0x18, wchar_count)
+        struct.pack_into("<Q", struct_data, 0x18, max(wchar_count, 8))
         struct.pack_into("<Q", struct_data, 0x20, target_gid)
 
         # Write struct to the hook's export buffer

--- a/wizwalker/memory/memory_objects/guild_chat_info.py
+++ b/wizwalker/memory/memory_objects/guild_chat_info.py
@@ -1,0 +1,52 @@
+from wizwalker.memory.memory_object import DynamicMemoryObject, PropertyClass
+from wizwalker.constants import Primitive
+
+
+# C++ class: GuildChatInfo
+# PropertyClass subclass (type hash: 1628314597)
+# Source: type dump r794925_Wizard_1_600.json
+#
+# Class layout:
+# ==============================================
+# Offset  Type            Description
+# ------  ----            -----------
+# 0x000   PropertyClass   Base (vtable + type info)
+# 0x048   gid (uint64)    Sender character GID
+# 0x050   std::string     Packed sender name
+# 0x070   std::string     Message text
+# 0x090   uint32          Message ID
+# 0x094   uint8           Send filter
+# 0x098   uint32          Message timestamp (epoch seconds)
+
+
+class GuildChatInfo(PropertyClass):
+    async def read_base_address(self) -> int:
+        raise NotImplementedError()
+
+    async def character_gid(self) -> int:
+        """Sender character GID at offset 0x48."""
+        return await self.read_value_from_offset(0x48, Primitive.uint64)
+
+    async def packed_name(self) -> str:
+        """Packed sender name at offset 0x50."""
+        return await self.read_string_from_offset(0x50)
+
+    async def message(self) -> str:
+        """Chat message text at offset 0x70."""
+        return await self.read_string_from_offset(0x70)
+
+    async def message_id(self) -> int:
+        """Server-assigned message ID at offset 0x90."""
+        return await self.read_value_from_offset(0x90, Primitive.uint32)
+
+    async def send_filter(self) -> int:
+        """Send filter flags at offset 0x94."""
+        return await self.read_value_from_offset(0x94, Primitive.uint8)
+
+    async def message_time(self) -> int:
+        """Message timestamp (epoch seconds) at offset 0x98."""
+        return await self.read_value_from_offset(0x98, Primitive.uint32)
+
+
+class DynamicGuildChatInfo(DynamicMemoryObject, GuildChatInfo):
+    pass


### PR DESCRIPTION
## Summary
- **ChatSendHook**: Bidirectional hook on the main game loop for sending directed chat and buddy requests on the main thread
- **ChatHook**: Hooks MSG_DirectedChat handler to extract sender GID and message text to persistent exports
- **ChatOwner**: `send_msg()`, `recv_message()`, `wait_for_message()`, `add_player()`
- **Memory objects**: BasicChatChannelInfo, BasicChatPlayer, GuildChatInfo from r794925 type dump
- Heap wstring support via game's own `operator new` for messages > 7 chars (max 79, server cap)

## Verification
Handler addresses and struct layouts verified via Ghidra static analysis of r794925. Pattern scans use `return_multiple=True` with probe-based disambiguation (type markers, string content verification). Tested live with two clients sending whispers, receiving messages, and adding buddies.

## Usage
```python
await client.hook_handler.activate_chat_send_hook()
await client.hook_handler.activate_chat_hook(wait_for_ready=False)

# Send whisper
await client.chat_owner.send_msg("Hello", target_gid=12345)

# Receive whisper
sender, msg, count = await client.chat_owner.wait_for_message(timeout=10)

# Send buddy request
await client.chat_owner.add_player(target_gid=12345)
```