### PR TITLE
Fix SpellListControl entry stride and field offsets

### DIFF
--- a/examples/debug_spell_list.py
+++ b/examples/debug_spell_list.py
@@ -1,0 +1,266 @@
+"""
+Diagnostic tool for SpellListControl memory layout.
+
+Probes the SpellList vector metadata, tests stride candidates, dumps
+raw hex, and scans field offsets to help identify the correct stride
+and field layout when spells are being read incorrectly.
+
+Prerequisites:
+  - Wizard101 must be running
+  - Spellbook must be open on the Deck page (SpellList visible)
+
+Usage:
+  py debug_spell_list.py
+"""
+
+import asyncio
+import struct
+
+from wizwalker import ClientHandler
+from wizwalker.constants import Primitive
+from wizwalker.extensions.scripting.utils import _maybe_get_named_window
+from wizwalker.memory.memory_object import DynamicMemoryObject
+from wizwalker.memory.memory_objects.spell import DynamicGraphicalSpell
+from wizwalker.memory.memory_objects.window import DynamicSpellListControl
+
+STRIDE_CANDIDATES = [
+    0x08, 0x10, 0x14, 0x18, 0x1C, 0x20, 0x24, 0x28,
+    0x30, 0x38, 0x40, 0x48, 0x50, 0x60, 0x70, 0x78,
+    0x80, 0x90, 0xA0, 0xA8, 0xB0, 0xC0, 0xD0, 0xE0,
+    0xF0, 0x100, 0x120, 0x150, 0x180, 0x200,
+]
+
+
+async def try_read_name(hook_handler, gfx_ptr: int) -> str | None:
+    try:
+        gfx = DynamicGraphicalSpell(hook_handler, gfx_ptr)
+        template = await gfx.spell_template()
+        if not template:
+            return None
+        name = await template.name()
+        return name if name else None
+    except Exception:
+        return None
+
+
+async def probe_entry(hook_handler, addr: int) -> tuple[int, str | None]:
+    """Read graphical_spell pointer at offset 0 and try to get a name."""
+    try:
+        obj = DynamicMemoryObject(hook_handler, addr)
+        gfx_ptr = await obj.read_value_from_offset(0x0, Primitive.uint64)
+        if gfx_ptr == 0:
+            return 0, None
+        name = await try_read_name(hook_handler, gfx_ptr)
+        return gfx_ptr, name
+    except Exception:
+        return 0, None
+
+
+async def section_vector_metadata(ctrl: DynamicSpellListControl):
+    print("=" * 60)
+    print("SECTION 1: Vector metadata at offset 0x280")
+    print("=" * 60)
+
+    start_ptr = await ctrl.read_value_from_offset(0x280, Primitive.uint64)
+    end_ptr_8  = await ctrl.read_value_from_offset(0x288, Primitive.uint64)
+    end_ptr_16 = await ctrl.read_value_from_offset(0x290, Primitive.uint64)
+
+    print(f"  start_ptr   (0x280) = 0x{start_ptr:016X}")
+    print(f"  end_ptr@+8  (0x288) = 0x{end_ptr_8:016X}  "
+          f"  range = {end_ptr_8 - start_ptr} bytes")
+    print(f"  end_ptr@+16 (0x290) = 0x{end_ptr_16:016X}  "
+          f"  range = {end_ptr_16 - start_ptr} bytes")
+    print()
+    print("  read_inlined_vector uses offset+16 (capacity?), "
+          "read_shared_vector uses offset+8 (end).")
+    print(f"  With stride 0xA8: offset+8  → {(end_ptr_8 - start_ptr) // 0xA8} entries")
+    print(f"  With stride 0xA8: offset+16 → {(end_ptr_16 - start_ptr) // 0xA8} entries")
+    print()
+
+    return start_ptr, end_ptr_8, end_ptr_16
+
+
+async def section_stride_probe(hook_handler, start_ptr: int, end_ptr: int):
+    print("=" * 60)
+    print("SECTION 2: Stride probe (using end_ptr@+8)")
+    print("=" * 60)
+    print(f"  {'stride':>8}  {'total':>6}  {'valid':>6}  {'named':>6}  names")
+    print(f"  {'-'*8}  {'-'*6}  {'-'*6}  {'-'*6}  -----")
+
+    best_stride = 0xA8
+    best_named = 0
+    results = []
+
+    for stride in STRIDE_CANDIDATES:
+        total = (end_ptr - start_ptr) // stride
+        if total == 0 or total > 200:
+            continue
+
+        valid_count = 0
+        named_count = 0
+        sample_names = []
+
+        for i in range(total):
+            addr = start_ptr + i * stride
+            gfx_ptr, name = await probe_entry(hook_handler, addr)
+            if gfx_ptr != 0:
+                valid_count += 1
+            if name:
+                named_count += 1
+                if len(sample_names) < 3:
+                    sample_names.append(name)
+
+        names_str = ", ".join(f'"{n}"' for n in sample_names) if sample_names else "-"
+        marker = " <--" if named_count > best_named else ""
+        print(f"  0x{stride:06X}  {total:>6}  {valid_count:>6}  {named_count:>6}  "
+              f"{names_str}{marker}")
+
+        results.append((stride, total, valid_count, named_count, sample_names))
+        if named_count > best_named:
+            best_named = named_count
+            best_stride = stride
+
+    print()
+    return best_stride, results
+
+
+async def section_entry_dump(hook_handler, start_ptr: int, end_ptr: int, stride: int):
+    print("=" * 60)
+    print(f"SECTION 3: Per-entry dump  (stride=0x{stride:X})")
+    print("=" * 60)
+
+    total = (end_ptr - start_ptr) // stride
+    for i in range(total):
+        addr = start_ptr + i * stride
+        try:
+            obj = DynamicMemoryObject(hook_handler, addr)
+            gfx_ptr  = await obj.read_value_from_offset(0x00, Primitive.uint64)
+            max_cop  = await obj.read_value_from_offset(0x10, Primitive.uint32)
+            cur_cop  = await obj.read_value_from_offset(0x14, Primitive.uint32)
+            name = None
+            if gfx_ptr != 0:
+                name = await try_read_name(hook_handler, gfx_ptr)
+            name_str = f'"{name}"' if name else ("(null ptr)" if gfx_ptr == 0 else "(unreadable)")
+            print(f"  [{i:>3}] addr=0x{addr:X}  gfx=0x{gfx_ptr:016X}  "
+                  f"max={max_cop}  cur={cur_cop}  name={name_str}")
+        except Exception as e:
+            print(f"  [{i:>3}] addr=0x{addr:X}  ERROR: {e}")
+
+    print()
+
+
+async def section_hex_dump(hook_handler, start_ptr: int, stride: int, n_entries: int = 3):
+    print("=" * 60)
+    print(f"SECTION 4: Raw hex dump  (first {n_entries} entries, stride=0x{stride:X})")
+    print("=" * 60)
+
+    size = stride * n_entries
+    try:
+        raw = await DynamicMemoryObject(hook_handler, start_ptr).read_bytes(start_ptr, size)
+    except Exception as e:
+        print(f"  ERROR reading bytes: {e}")
+        print()
+        return
+
+    bytes_per_row = 16
+    for row_start in range(0, len(raw), bytes_per_row):
+        chunk = raw[row_start:row_start + bytes_per_row]
+        hex_part = " ".join(f"{b:02X}" for b in chunk)
+        asc_part = "".join(chr(b) if 0x20 <= b < 0x7F else "." for b in chunk)
+        entry_marker = ""
+        if row_start % stride == 0:
+            entry_marker = f"  ← entry {row_start // stride}"
+        print(f"  +{row_start:04X}  {hex_part:<47}  {asc_part}{entry_marker}")
+
+    print()
+
+
+async def section_field_probe(hook_handler, start_ptr: int, stride: int):
+    print("=" * 60)
+    print(f"SECTION 5: Field offset probe on entry 0  (stride=0x{stride:X})")
+    print("=" * 60)
+    print("  Reading every 4-byte-aligned uint32 and uint64 up to min(stride, 0x100)")
+    print()
+
+    limit = min(stride, 0x100)
+    obj = DynamicMemoryObject(hook_handler, start_ptr)
+
+    print(f"  {'offset':>8}   {'uint32':>12}   {'uint64':>20}")
+    print(f"  {'-'*8}   {'-'*12}   {'-'*20}")
+
+    offset = 0
+    while offset + 4 <= limit:
+        try:
+            v32 = await obj.read_value_from_offset(offset, Primitive.uint32)
+        except Exception:
+            v32 = None
+
+        v64_str = ""
+        if offset + 8 <= limit:
+            try:
+                v64 = await obj.read_value_from_offset(offset, Primitive.uint64)
+                v64_str = f"0x{v64:016X}"
+            except Exception:
+                v64_str = "error"
+
+        v32_str = f"{v32}" if v32 is not None else "error"
+        print(f"  0x{offset:06X}   {v32_str:>12}   {v64_str}")
+        offset += 4
+
+    print()
+
+
+async def main():
+    handler = ClientHandler()
+    clients = handler.get_new_clients()
+    if not clients:
+        print("No Wizard101 client found. Start the game first.")
+        return
+
+    client = clients[0]
+
+    try:
+        print("Activating root window hook...")
+        await client.hook_handler.activate_root_window_hook()
+        print("Ready.\n")
+
+        try:
+            deck_config = await _maybe_get_named_window(client.root_window, "DeckConfiguration")
+        except ValueError:
+            print("ERROR: DeckConfiguration window not found.")
+            print("Open the spellbook and navigate to the Deck page first.")
+            return
+
+        try:
+            spell_list_win = await _maybe_get_named_window(deck_config, "SpellList")
+        except ValueError:
+            print("ERROR: SpellList window not found inside DeckConfiguration.")
+            return
+
+        base_addr = await spell_list_win.read_base_address()
+        print(f"SpellListControl base address: 0x{base_addr:X}\n")
+
+        ctrl = DynamicSpellListControl(client.hook_handler, base_addr)
+
+        start_ptr, end_ptr_8, end_ptr_16 = await section_vector_metadata(ctrl)
+
+        if start_ptr == 0 or end_ptr_8 <= start_ptr:
+            print("ERROR: Invalid vector pointers — is the SpellList window visible and populated?")
+            return
+
+        best_stride, _ = await section_stride_probe(client.hook_handler, start_ptr, end_ptr_8)
+
+        print(f"Best stride determined: 0x{best_stride:X}\n")
+
+        await section_entry_dump(client.hook_handler, start_ptr, end_ptr_8, best_stride)
+        await section_hex_dump(client.hook_handler, start_ptr, best_stride)
+        await section_field_probe(client.hook_handler, start_ptr, best_stride)
+
+    finally:
+        print("Closing...")
+        await handler.close()
+        print("Done.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/save_and_load_deck.py
+++ b/examples/save_and_load_deck.py
@@ -6,8 +6,8 @@ Prerequisites:
   - Character must be in a safe location (not in combat)
 
 Usage:
-  py test_deck_save_load.py
-  py test_deck_save_load.py --save-path my_deck.json
+  py save_and_load_deck.py
+  py save_and_load_deck.py --save-path my_deck.json
 """
 
 import asyncio

--- a/examples/save_and_load_deck.py
+++ b/examples/save_and_load_deck.py
@@ -1,0 +1,152 @@
+"""
+Test script: save deck to JSON, clear it, then restore it.
+
+Prerequisites:
+  - Wizard101 must be running
+  - Character must be in a safe location (not in combat)
+
+Usage:
+  py test_deck_save_load.py
+  py test_deck_save_load.py --save-path my_deck.json
+"""
+
+import asyncio
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Use the local repo rather than the installed package
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from wizwalker import ClientHandler
+from wizwalker.extensions.scripting.deck_builder import DeckBuilder
+
+DEFAULT_SAVE_PATH = Path("deck_backup.json")
+
+
+async def main(save_path: Path):
+    handler = ClientHandler()
+    clients = handler.get_new_clients()
+    if not clients:
+        print("No Wizard101 client found. Start the game first.")
+        return
+
+    client = clients[0]
+
+    try:
+        print("Activating hooks...")
+        await client.activate_hooks()
+        print("Ready.\n")
+
+        async with DeckBuilder(client) as db:
+            # --- Step 1: Save ---
+            print("Step 1: Reading current deck...")
+            preset = await db.get_deck_preset()
+
+            normal_total = sum(preset["normal"].values())
+            tc_total     = sum(preset["tc"].values())
+            item_total   = sum(preset["item"].values())
+            print(f"  Normal cards : {normal_total} ({len(preset['normal'])} unique)")
+            print(f"  Treasure cards: {tc_total} ({len(preset['tc'])} unique)")
+            print(f"  Item cards   : {item_total} ({len(preset['item'])} unique)")
+
+            save_path.write_text(json.dumps(preset, indent=2))
+            print(f"\n  Saved to {save_path.resolve()}\n")
+
+            # --- Step 2: Clear ---
+            print("Step 2: Clearing deck...")
+            await db.clear_full_deck()
+            print("  Done.\n")
+
+            # --- Step 3: Verify clear ---
+            print("Step 3: Verifying deck is empty...")
+            await db.refresh_deck_page()
+            count_after_clear = await db.get_deck_count()
+            if count_after_clear != 0:
+                print(f"  WARNING: deck still shows {count_after_clear} card(s) after clear.")
+            else:
+                print("  Deck is empty. OK\n")
+
+            # --- Step 4: Debug spell list ---
+            loaded = json.loads(save_path.read_text())
+            print("Step 4: Dumping available spell list...")
+            spell_entries = await db.get_spell_list()
+            available = []
+            for entry in spell_entries:
+                try:
+                    gfx = await entry.graphical_spell()
+                    if not gfx:
+                        continue
+                    tmpl = await gfx.spell_template()
+                    if not tmpl:
+                        continue
+                    available.append(await tmpl.name())
+                except Exception:
+                    pass
+            print(f"  {len(available)} spells visible in SpellList:")
+            for name in available:
+                print(f"    {name}")
+
+            wanted = set(loaded["normal"].keys()) | set(loaded["tc"].keys())
+            missing = wanted - set(available)
+            if missing:
+                print(f"\n  Cards in preset NOT found in spell list:")
+                for name in sorted(missing):
+                    print(f"    MISSING: {name}")
+            else:
+                print("\n  All preset cards found in spell list. OK")
+            print()
+
+            # --- Step 5: Restore ---
+            print("Step 5: Restoring deck from saved preset...")
+            await db.set_deck_preset(loaded)
+            print("  Done.\n")
+
+            # --- Step 6: Verify restore ---
+            print("Step 6: Verifying restored deck...")
+            await db.refresh_deck_page()
+            restored = await db.get_deck_preset()
+
+            mismatches = []
+            for section in ("normal", "tc", "item"):
+                orig = preset[section]
+                rest = restored[section]
+                for name, count in orig.items():
+                    if rest.get(name, 0) != count:
+                        mismatches.append(
+                            f"  {section}/{name}: expected {count}, got {rest.get(name, 0)}"
+                        )
+                for name in rest:
+                    if name not in orig:
+                        mismatches.append(
+                            f"  {section}/{name}: unexpected card in restored deck"
+                        )
+
+            if mismatches:
+                print("  FAIL — mismatches found:")
+                for m in mismatches:
+                    print(m)
+            else:
+                restored_normal = sum(restored["normal"].values())
+                restored_tc     = sum(restored["tc"].values())
+                restored_item   = sum(restored["item"].values())
+                print(f"  Normal cards : {restored_normal} (expected {normal_total})")
+                print(f"  Treasure cards: {restored_tc} (expected {tc_total})")
+                print(f"  Item cards   : {restored_item} (expected {item_total})")
+                print("\n  PASS — deck restored successfully.")
+
+    finally:
+        print("\nClosing...")
+        await handler.close()
+        print("Done.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Save, clear, and restore a Wizard101 deck.")
+    parser.add_argument(
+        "--save-path", type=Path, default=DEFAULT_SAVE_PATH,
+        help=f"Path to write the deck JSON (default: {DEFAULT_SAVE_PATH})",
+    )
+    args = parser.parse_args()
+    asyncio.run(main(args.save_path))

--- a/wizwalker/memory/memory_object.py
+++ b/wizwalker/memory/memory_object.py
@@ -331,7 +331,7 @@ class MemoryObject(MemoryReader):
             object_type: type,
     ):
         start = await self.read_value_from_offset(offset, Primitive.uint64)
-        end = await self.read_value_from_offset(offset + 16, Primitive.uint64)
+        end = await self.read_value_from_offset(offset + 8, Primitive.uint64)
 
         total_size = (end - start) // object_size
 

--- a/wizwalker/memory/memory_objects/window.py
+++ b/wizwalker/memory/memory_objects/window.py
@@ -368,7 +368,7 @@ class SpellListControlSpellEntry(DynamicMemoryObject):
         return await self.read_value_from_offset(0x14, Primitive.uint32)
 
     async def enabled(self) -> bool:
-        return bool(await self.read_value_from_offset(0xA0, Primitive.uint8))
+        return bool(await self.read_value_from_offset(0x70, Primitive.uint8))
 
     async def _read_vector(self, address: int, size: int = 3, data_type: Primitive = Primitive.float32):
         type_str = data_type.value.format.replace("<", "")
@@ -421,7 +421,7 @@ class SpellListControl(Window):
         raise NotImplementedError()
 
     async def spell_entries(self) -> List[SpellListControlSpellEntry]:
-        return await self.read_inlined_vector(0x280, 0xA8, SpellListControlSpellEntry)
+        return await self.read_inlined_vector(0x280, 0x78, SpellListControlSpellEntry)
 
     async def card_size_horizontal(self) -> int:
         return await self.read_value_from_offset(0x30C, Primitive.uint32)


### PR DESCRIPTION
## Summary

- Fix `SpellListControl` entry stride so the full spell list is read correctly
- Fix `read_inlined_vector` end pointer offset (latent over-read bug)
- Fix `SpellListControlSpellEntry.enabled()` field offset left out of bounds by the stride change

## Background

`DeckBuilder.get_spell_list()` was returning only every ~7th spell correctly. The root cause was a mismatch between the stride passed to `read_inlined_vector` (`0xA8`) and the actual in-memory size of `SpellListControlSpellEntry` (`0x78`). With an incorrect stride, reads become misaligned after the first entry — only entries whose addresses happened to land on a correct boundary returned valid data.

Offsets were confirmed using a live memory probe against a running client. With stride `0x78`, all 94 spells in the test character's spell list were read correctly by name.

## Changes

**`wizwalker/memory/memory_object.py`**
- `read_inlined_vector`: read the vector end pointer from `offset + 8` instead of `offset + 16`. Standard C++ vector layout places the end pointer at `+8` and the capacity pointer at `+16`. The previous code read capacity as end, over-counting entries whenever the vector has unused capacity. This was masked when the vector happened to be full.

**`wizwalker/memory/memory_objects/window.py`**
- `SpellListControl.spell_entries`: update entry stride `0xA8` → `0x78`
- `SpellListControlSpellEntry.enabled`: update field offset `0xA0` → `0x70` — the old offset was 40 bytes past the end of the now-smaller struct, reading into the following entry

## New files

- `examples/debug_spell_list.py` — diagnostic tool that probes vector metadata, tests stride candidates, dumps raw hex, and scans field offsets; useful for re-verifying offsets after future game updates
- `examples/save_and_load_deck.py` — end-to-end test that saves the current deck to JSON, clears it, restores it, and verifies the result matches
